### PR TITLE
chore(deps): bump dependency versions

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.8](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.8) | 
+[zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.7](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.7) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.7](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.7) | 
+[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.9](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.9) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -1,0 +1,5 @@
+# Dependency Matrix
+
+Dependency | Sources | Version | Mismatched versions
+---------- | ------- | ------- | -------------------
+[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.8](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.8) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: zeebe-io
-  repo: zeebe-operate-helm
-  url: https://github.com/zeebe-io/zeebe-operate-helm
-  version: 0.0.7
-  versionURL: https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.7
+  repo: zeebe-cluster-helm
+  url: https://github.com/zeebe-io/zeebe-cluster-helm
+  version: 0.0.9
+  versionURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.9

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,0 +1,7 @@
+dependencies:
+- host: github.com
+  owner: zeebe-io
+  repo: zeebe-cluster-helm
+  url: https://github.com/zeebe-io/zeebe-cluster-helm
+  version: 0.0.8
+  versionURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.8

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: zeebe-io
-  repo: zeebe-cluster-helm
-  url: https://github.com/zeebe-io/zeebe-cluster-helm
-  version: 0.0.8
-  versionURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.8
+  repo: zeebe-operate-helm
+  url: https://github.com/zeebe-io/zeebe-operate-helm
+  version: 0.0.7
+  versionURL: https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.7

--- a/zeebe-full/requirements.yaml
+++ b/zeebe-full/requirements.yaml
@@ -2,11 +2,11 @@ dependencies:
 - alias: zeebe
   name: zeebe-cluster
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.8
+  version: 0.0.2
 - alias: operate
   name: zeebe-operate
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.3
+  version: 0.0.7
 - name: nginx-ingress
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 1.19.0

--- a/zeebe-full/requirements.yaml
+++ b/zeebe-full/requirements.yaml
@@ -2,11 +2,11 @@ dependencies:
 - alias: zeebe
   name: zeebe-cluster
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.2
+  version: 0.0.9
 - alias: operate
   name: zeebe-operate
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.7
+  version: 0.0.3
 - name: nginx-ingress
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 1.19.0

--- a/zeebe-full/requirements.yaml
+++ b/zeebe-full/requirements.yaml
@@ -1,13 +1,12 @@
 dependencies:
-- name: zeebe-cluster
-  version: 0.0.2
+- alias: zeebe
+  name: zeebe-cluster
   repository: http://jenkins-x-chartmuseum:8080
-  alias: zeebe
-- name: zeebe-operate
+  version: 0.0.8
+- alias: operate
+  name: zeebe-operate
+  repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.3
-  repository: http://jenkins-x-chartmuseum:8080
-  alias: operate
 - name: nginx-ingress
-  version: 1.19.0
   repository: https://kubernetes-charts.storage.googleapis.com
-  
+  version: 1.19.0


### PR DESCRIPTION
Update [zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) from [0.0.2](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.2) to [0.0.9](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.9)

Command run was `jx step create pr chart --name zeebe-cluster --version 0.0.9 --repo https://github.com/zeebe-io/zeebe-full-helm.git`
<hr />

Update [zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) from [0.0.3](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.3) to [0.0.7](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.7)

Command run was `jx step create pr chart --name zeebe-operate --version 0.0.7 --repo https://github.com/zeebe-io/zeebe-full-helm.git`
<hr />

Update [zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) from [0.0.2](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.2) to [0.0.8](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.8)

Command run was `jx step create pr chart --name zeebe-cluster --version 0.0.8 --repo https://github.com/zeebe-io/zeebe-full-helm.git`