### PR TITLE
chore(deps): bump https://github.com/zeebe-io/zeebe-operate-helm from 0.0.3 to 0.0.8

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,3 +3,4 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.9](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.9) | 
+[zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.8](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.8) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -5,3 +5,9 @@ dependencies:
   url: https://github.com/zeebe-io/zeebe-cluster-helm
   version: 0.0.9
   versionURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.9
+- host: github.com
+  owner: zeebe-io
+  repo: zeebe-operate-helm
+  url: https://github.com/zeebe-io/zeebe-operate-helm
+  version: 0.0.8
+  versionURL: https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.8

--- a/zeebe-full/requirements.yaml
+++ b/zeebe-full/requirements.yaml
@@ -6,7 +6,7 @@ dependencies:
 - alias: operate
   name: zeebe-operate
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.3
+  version: 0.0.8
 - name: nginx-ingress
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 1.19.0


### PR DESCRIPTION
Update [zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) from [0.0.3](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.3) to [0.0.8](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.8)

Command run was `jx step create pr chart --name zeebe-operate --version 0.0.8 --repo https://github.com/zeebe-io/zeebe-full-helm.git`