### PR TITLE
chore(deps): bump

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,5 +2,5 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.31](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.31) | 
+[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.32](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.32) | 
 [zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.10](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.10) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,5 +2,5 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.32](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.32) | 
-[zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.10](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.10) | 
+[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.22](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.22) | 
+[zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.11](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.11) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,5 +2,5 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.22](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.22) | 
+[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.27](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.27) | 
 [zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.10](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.10) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,5 +2,5 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.27](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.27) | 
+[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.29](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.29) | 
 [zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.10](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.10) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,5 +2,5 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.29](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.29) | 
+[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.30](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.30) | 
 [zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.10](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.10) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,5 +2,5 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.30](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.30) | 
+[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.31](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.31) | 
 [zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.10](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.10) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: zeebe-io
   repo: zeebe-cluster-helm
   url: https://github.com/zeebe-io/zeebe-cluster-helm
-  version: 0.0.30
-  versionURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.30
+  version: 0.0.31
+  versionURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.31
 - host: github.com
   owner: zeebe-io
   repo: zeebe-operate-helm

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: zeebe-io
   repo: zeebe-cluster-helm
   url: https://github.com/zeebe-io/zeebe-cluster-helm
-  version: 0.0.27
-  versionURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.27
+  version: 0.0.29
+  versionURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.29
 - host: github.com
   owner: zeebe-io
   repo: zeebe-operate-helm

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -9,5 +9,5 @@ dependencies:
   owner: zeebe-io
   repo: zeebe-operate-helm
   url: https://github.com/zeebe-io/zeebe-operate-helm
-  version: 0.0.10
-  versionURL: https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.10
+  version: 0.0.11
+  versionURL: https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.11

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: zeebe-io
   repo: zeebe-cluster-helm
   url: https://github.com/zeebe-io/zeebe-cluster-helm
-  version: 0.0.31
-  versionURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.31
+  version: 0.0.32
+  versionURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.32
 - host: github.com
   owner: zeebe-io
   repo: zeebe-operate-helm

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: zeebe-io
   repo: zeebe-cluster-helm
   url: https://github.com/zeebe-io/zeebe-cluster-helm
-  version: 0.0.29
-  versionURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.29
+  version: 0.0.30
+  versionURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.30
 - host: github.com
   owner: zeebe-io
   repo: zeebe-operate-helm

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: zeebe-io
   repo: zeebe-cluster-helm
   url: https://github.com/zeebe-io/zeebe-cluster-helm
-  version: 0.0.22
-  versionURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.22
+  version: 0.0.27
+  versionURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.27
 - host: github.com
   owner: zeebe-io
   repo: zeebe-operate-helm

--- a/zeebe-full/requirements.yaml
+++ b/zeebe-full/requirements.yaml
@@ -2,7 +2,7 @@ dependencies:
 - alias: zeebe
   name: zeebe-cluster
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.22
+  version: 0.0.27
 - alias: operate
   name: zeebe-operate
   repository: http://jenkins-x-chartmuseum:8080

--- a/zeebe-full/requirements.yaml
+++ b/zeebe-full/requirements.yaml
@@ -2,7 +2,7 @@ dependencies:
 - alias: zeebe
   name: zeebe-cluster
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.31
+  version: 0.0.32
 - alias: operate
   name: zeebe-operate
   repository: http://jenkins-x-chartmuseum:8080

--- a/zeebe-full/requirements.yaml
+++ b/zeebe-full/requirements.yaml
@@ -2,7 +2,7 @@ dependencies:
 - alias: zeebe
   name: zeebe-cluster
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.29
+  version: 0.0.30
 - alias: operate
   name: zeebe-operate
   repository: http://jenkins-x-chartmuseum:8080

--- a/zeebe-full/requirements.yaml
+++ b/zeebe-full/requirements.yaml
@@ -2,7 +2,7 @@ dependencies:
 - alias: zeebe
   name: zeebe-cluster
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.30
+  version: 0.0.31
 - alias: operate
   name: zeebe-operate
   repository: http://jenkins-x-chartmuseum:8080

--- a/zeebe-full/requirements.yaml
+++ b/zeebe-full/requirements.yaml
@@ -2,7 +2,7 @@ dependencies:
 - alias: zeebe
   name: zeebe-cluster
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.27
+  version: 0.0.29
 - alias: operate
   name: zeebe-operate
   repository: http://jenkins-x-chartmuseum:8080

--- a/zeebe-full/requirements.yaml
+++ b/zeebe-full/requirements.yaml
@@ -6,7 +6,7 @@ dependencies:
 - alias: operate
   name: zeebe-operate
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.10
+  version: 0.0.11
 - name: nginx-ingress
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 1.19.0


### PR DESCRIPTION
Update [zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) from [0.0.10](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.10) to [0.0.11](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.11)

Command run was `jx step create pr chart --name zeebe-operate --version 0.0.11 --repo https://github.com/zeebe-io/zeebe-full-helm.git`
<hr />

Update [zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) from [0.0.22](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.22) to [0.0.32](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.32)

Command run was `jx step create pr chart --name zeebe-cluster --version 0.0.32 --repo https://github.com/zeebe-io/zeebe-full-helm.git`
<hr />

Update [zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) from [0.0.22](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.22) to [0.0.31](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.31)

Command run was `jx step create pr chart --name zeebe-cluster --version 0.0.31 --repo https://github.com/zeebe-io/zeebe-full-helm.git`
<hr />

Update [zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) from [0.0.22](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.22) to [0.0.30](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.30)

Command run was `jx step create pr chart --name zeebe-cluster --version 0.0.30 --repo https://github.com/zeebe-io/zeebe-full-helm.git`
<hr />

Update [zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) from [0.0.22](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.22) to [0.0.29](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.29)

Command run was `jx step create pr chart --name zeebe-cluster --version 0.0.29 --repo https://github.com/zeebe-io/zeebe-full-helm.git`
<hr />

Update [zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) from [0.0.22](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.22) to [0.0.27](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.27)

Command run was `jx step create pr chart --name zeebe-cluster --version 0.0.27 --repo https://github.com/zeebe-io/zeebe-full-helm.git`