### PR TITLE
chore(deps): bump https://github.com/zeebe-io/zeebe-operate-helm from 0.0.11 to 0.0.12

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,4 +3,4 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.34](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.34) | 
-[zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.11](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.11) | 
+[zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.12](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.12) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -9,5 +9,5 @@ dependencies:
   owner: zeebe-io
   repo: zeebe-operate-helm
   url: https://github.com/zeebe-io/zeebe-operate-helm
-  version: 0.0.11
-  versionURL: https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.11
+  version: 0.0.12
+  versionURL: https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.12

--- a/zeebe-full/requirements.yaml
+++ b/zeebe-full/requirements.yaml
@@ -6,7 +6,7 @@ dependencies:
 - alias: operate
   name: zeebe-operate
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.11
+  version: 0.0.12
 - name: nginx-ingress
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 1.19.0


### PR DESCRIPTION
Update [zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) from [0.0.11](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.11) to [0.0.12](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.12)

Command run was `jx step create pr chart --name zeebe-operate --version 0.0.12 --repo https://github.com/zeebe-io/zeebe-full-helm.git`