### PR TITLE
chore(deps): bump

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,5 +2,5 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.34](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.34) | 
+[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.35](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.35) | 
 [zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.12](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.12) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,5 +2,5 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.35](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.35) | 
+[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.36](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.36) | 
 [zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.12](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.12) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,5 +2,5 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.36](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.36) | 
-[zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.12](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.12) | 
+[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.34](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.34) | 
+[zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.13](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.13) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: zeebe-io
   repo: zeebe-cluster-helm
   url: https://github.com/zeebe-io/zeebe-cluster-helm
-  version: 0.0.34
-  versionURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.34
+  version: 0.0.35
+  versionURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.35
 - host: github.com
   owner: zeebe-io
   repo: zeebe-operate-helm

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -9,5 +9,5 @@ dependencies:
   owner: zeebe-io
   repo: zeebe-operate-helm
   url: https://github.com/zeebe-io/zeebe-operate-helm
-  version: 0.0.12
-  versionURL: https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.12
+  version: 0.0.13
+  versionURL: https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.13

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: zeebe-io
   repo: zeebe-cluster-helm
   url: https://github.com/zeebe-io/zeebe-cluster-helm
-  version: 0.0.35
-  versionURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.35
+  version: 0.0.36
+  versionURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.36
 - host: github.com
   owner: zeebe-io
   repo: zeebe-operate-helm

--- a/zeebe-full/requirements.yaml
+++ b/zeebe-full/requirements.yaml
@@ -6,7 +6,7 @@ dependencies:
 - alias: operate
   name: zeebe-operate
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.12
+  version: 0.0.13
 - name: nginx-ingress
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 1.19.0

--- a/zeebe-full/requirements.yaml
+++ b/zeebe-full/requirements.yaml
@@ -2,7 +2,7 @@ dependencies:
 - alias: zeebe
   name: zeebe-cluster
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.34
+  version: 0.0.35
 - alias: operate
   name: zeebe-operate
   repository: http://jenkins-x-chartmuseum:8080

--- a/zeebe-full/requirements.yaml
+++ b/zeebe-full/requirements.yaml
@@ -2,7 +2,7 @@ dependencies:
 - alias: zeebe
   name: zeebe-cluster
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.35
+  version: 0.0.36
 - alias: operate
   name: zeebe-operate
   repository: http://jenkins-x-chartmuseum:8080


### PR DESCRIPTION
Update [zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) from [0.0.12](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.12) to [0.0.13](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.13)

Command run was `jx step create pr chart --name zeebe-operate --version 0.0.13 --repo https://github.com/zeebe-io/zeebe-full-helm.git`
<hr />

Update [zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) from [0.0.34](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.34) to [0.0.36](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.36)

Command run was `jx step create pr chart --name zeebe-cluster --version 0.0.36 --repo https://github.com/zeebe-io/zeebe-full-helm.git`
<hr />

Update [zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) from [0.0.34](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.34) to [0.0.35](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.35)

Command run was `jx step create pr chart --name zeebe-cluster --version 0.0.35 --repo https://github.com/zeebe-io/zeebe-full-helm.git`