### PR TITLE
chore(deps): bump from

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,5 +2,5 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.43](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.43) | 
+[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.44](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.44) | 
 [zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.14](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.14) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,5 +2,5 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.44](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.44) | 
-[zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.14](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.14) | 
+[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.43](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.43) | 
+[zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.15](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.15) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -9,5 +9,5 @@ dependencies:
   owner: zeebe-io
   repo: zeebe-operate-helm
   url: https://github.com/zeebe-io/zeebe-operate-helm
-  version: 0.0.14
-  versionURL: https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.14
+  version: 0.0.15
+  versionURL: https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.15

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: zeebe-io
   repo: zeebe-cluster-helm
   url: https://github.com/zeebe-io/zeebe-cluster-helm
-  version: 0.0.43
-  versionURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.43
+  version: 0.0.44
+  versionURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.44
 - host: github.com
   owner: zeebe-io
   repo: zeebe-operate-helm

--- a/zeebe-full/requirements.yaml
+++ b/zeebe-full/requirements.yaml
@@ -2,7 +2,7 @@ dependencies:
 - alias: zeebe
   name: zeebe-cluster
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.43
+  version: 0.0.44
 - alias: operate
   name: zeebe-operate
   repository: http://jenkins-x-chartmuseum:8080

--- a/zeebe-full/requirements.yaml
+++ b/zeebe-full/requirements.yaml
@@ -6,7 +6,7 @@ dependencies:
 - alias: operate
   name: zeebe-operate
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.14
+  version: 0.0.15
 - name: nginx-ingress
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 1.26.2


### PR DESCRIPTION
Update [zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) from [0.0.14](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.14) to [0.0.15](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.15)

Command run was `jx step create pr chart --name zeebe-operate --version 0.0.15 --repo https://github.com/zeebe-io/zeebe-full-helm.git`
<hr />

Update [zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) from [0.0.43](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.43) to [0.0.44](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.44)

Command run was `jx step create pr chart --name zeebe-cluster --version 0.0.44 --repo https://github.com/zeebe-io/zeebe-full-helm.git`