### PR TITLE
chore(deps): bump https://github.com/zeebe-io/zeebe-cluster-helm from 0.0.44 to 0.0.45

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,5 +2,5 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.43](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.43) | 
+[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.45](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.45) | 
 [zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.15](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.15) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: zeebe-io
   repo: zeebe-cluster-helm
   url: https://github.com/zeebe-io/zeebe-cluster-helm
-  version: 0.0.44
-  versionURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.44
+  version: 0.0.45
+  versionURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.45
 - host: github.com
   owner: zeebe-io
   repo: zeebe-operate-helm

--- a/zeebe-full/requirements.yaml
+++ b/zeebe-full/requirements.yaml
@@ -2,7 +2,7 @@ dependencies:
 - alias: zeebe
   name: zeebe-cluster
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.44
+  version: 0.0.45
 - alias: operate
   name: zeebe-operate
   repository: http://jenkins-x-chartmuseum:8080


### PR DESCRIPTION
Update [zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) from [0.0.44](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.44) to [0.0.45](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.45)

Command run was `jx step create pr chart --name zeebe-cluster --version 0.0.45 --repo https://github.com/zeebe-io/zeebe-full-helm.git`