### PR TITLE
chore(deps): bump https://github.com/zeebe-io/zeebe-cluster-helm from 0.0.48 to 0.0.49

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,5 +2,5 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.46](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.46) | 
+[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.49](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.49) | 
 [zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.16](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.16) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: zeebe-io
   repo: zeebe-cluster-helm
   url: https://github.com/zeebe-io/zeebe-cluster-helm
-  version: 0.0.48
-  versionURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.48
+  version: 0.0.49
+  versionURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.49
 - host: github.com
   owner: zeebe-io
   repo: zeebe-operate-helm

--- a/zeebe-full/requirements.yaml
+++ b/zeebe-full/requirements.yaml
@@ -2,7 +2,7 @@ dependencies:
 - alias: zeebe
   name: zeebe-cluster
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.48
+  version: 0.0.49
 - alias: operate
   name: zeebe-operate
   repository: http://jenkins-x-chartmuseum:8080


### PR DESCRIPTION
Update [zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) from [0.0.48](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.48) to [0.0.49](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.49)

Command run was `jx step create pr chart --name zeebe-cluster --version 0.0.49 --repo https://github.com/zeebe-io/zeebe-full-helm.git`