### PR TITLE
chore(deps): bump https://github.com/zeebe-io/zeebe-cluster-helm from 0.0.63

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,5 +2,5 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.65](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.65) | 
+[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.66](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.66) | 
 [zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.17](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.17) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,5 +2,5 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.64](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.64) | 
+[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.65](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.65) | 
 [zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.17](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.17) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,5 +2,5 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.63](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.63) | 
+[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.64](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.64) | 
 [zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.17](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.17) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: zeebe-io
   repo: zeebe-cluster-helm
   url: https://github.com/zeebe-io/zeebe-cluster-helm
-  version: 0.0.65
-  versionURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.65
+  version: 0.0.66
+  versionURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.66
 - host: github.com
   owner: zeebe-io
   repo: zeebe-operate-helm

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: zeebe-io
   repo: zeebe-cluster-helm
   url: https://github.com/zeebe-io/zeebe-cluster-helm
-  version: 0.0.63
-  versionURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.63
+  version: 0.0.64
+  versionURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.64
 - host: github.com
   owner: zeebe-io
   repo: zeebe-operate-helm

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: zeebe-io
   repo: zeebe-cluster-helm
   url: https://github.com/zeebe-io/zeebe-cluster-helm
-  version: 0.0.64
-  versionURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.64
+  version: 0.0.65
+  versionURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.65
 - host: github.com
   owner: zeebe-io
   repo: zeebe-operate-helm

--- a/zeebe-full/requirements.yaml
+++ b/zeebe-full/requirements.yaml
@@ -2,7 +2,7 @@ dependencies:
 - alias: zeebe
   name: zeebe-cluster
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.64
+  version: 0.0.65
 - alias: operate
   name: zeebe-operate
   repository: http://jenkins-x-chartmuseum:8080

--- a/zeebe-full/requirements.yaml
+++ b/zeebe-full/requirements.yaml
@@ -2,7 +2,7 @@ dependencies:
 - alias: zeebe
   name: zeebe-cluster
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.63
+  version: 0.0.64
 - alias: operate
   name: zeebe-operate
   repository: http://jenkins-x-chartmuseum:8080

--- a/zeebe-full/requirements.yaml
+++ b/zeebe-full/requirements.yaml
@@ -2,7 +2,7 @@ dependencies:
 - alias: zeebe
   name: zeebe-cluster
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.65
+  version: 0.0.66
 - alias: operate
   name: zeebe-operate
   repository: http://jenkins-x-chartmuseum:8080


### PR DESCRIPTION
Update [zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) from [0.0.63](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.63) to [0.0.66](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.66)

Command run was `jx step create pr chart --name zeebe-cluster --version 0.0.66 --repo https://github.com/zeebe-io/zeebe-full-helm.git`
<hr />

Update [zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) from [0.0.63](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.63) to [0.0.65](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.65)

Command run was `jx step create pr chart --name zeebe-cluster --version 0.0.65 --repo https://github.com/zeebe-io/zeebe-full-helm.git`
<hr />

Update [zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) from [0.0.63](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.63) to [0.0.64](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.64)

Command run was `jx step create pr chart --name zeebe-cluster --version 0.0.64 --repo https://github.com/zeebe-io/zeebe-full-helm.git`