### PR TITLE
chore(deps): bump https://github.com/zeebe-io/zeebe-cluster-helm from 0.0.76

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,5 +2,5 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.83](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.83) | 
+[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.84](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.84) | 
 [zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.18](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.18) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,5 +2,5 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.76](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.76) | 
+[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.77](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.77) | 
 [zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.18](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.18) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,5 +2,5 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.78](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.78) | 
+[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.79](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.79) | 
 [zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.18](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.18) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,5 +2,5 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.81](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.81) | 
+[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.82](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.82) | 
 [zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.18](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.18) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,5 +2,5 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.82](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.82) | 
+[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.83](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.83) | 
 [zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.18](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.18) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,5 +2,5 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.79](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.79) | 
+[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.80](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.80) | 
 [zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.18](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.18) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,5 +2,5 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.80](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.80) | 
+[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.81](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.81) | 
 [zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.18](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.18) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,5 +2,5 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.77](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.77) | 
+[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.78](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.78) | 
 [zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.18](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.18) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: zeebe-io
   repo: zeebe-cluster-helm
   url: https://github.com/zeebe-io/zeebe-cluster-helm
-  version: 0.0.82
-  versionURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.82
+  version: 0.0.83
+  versionURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.83
 - host: github.com
   owner: zeebe-io
   repo: zeebe-operate-helm

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: zeebe-io
   repo: zeebe-cluster-helm
   url: https://github.com/zeebe-io/zeebe-cluster-helm
-  version: 0.0.83
-  versionURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.83
+  version: 0.0.84
+  versionURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.84
 - host: github.com
   owner: zeebe-io
   repo: zeebe-operate-helm

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: zeebe-io
   repo: zeebe-cluster-helm
   url: https://github.com/zeebe-io/zeebe-cluster-helm
-  version: 0.0.78
-  versionURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.78
+  version: 0.0.79
+  versionURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.79
 - host: github.com
   owner: zeebe-io
   repo: zeebe-operate-helm

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: zeebe-io
   repo: zeebe-cluster-helm
   url: https://github.com/zeebe-io/zeebe-cluster-helm
-  version: 0.0.81
-  versionURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.81
+  version: 0.0.82
+  versionURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.82
 - host: github.com
   owner: zeebe-io
   repo: zeebe-operate-helm

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: zeebe-io
   repo: zeebe-cluster-helm
   url: https://github.com/zeebe-io/zeebe-cluster-helm
-  version: 0.0.76
-  versionURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.76
+  version: 0.0.77
+  versionURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.77
 - host: github.com
   owner: zeebe-io
   repo: zeebe-operate-helm

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: zeebe-io
   repo: zeebe-cluster-helm
   url: https://github.com/zeebe-io/zeebe-cluster-helm
-  version: 0.0.79
-  versionURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.79
+  version: 0.0.80
+  versionURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.80
 - host: github.com
   owner: zeebe-io
   repo: zeebe-operate-helm

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: zeebe-io
   repo: zeebe-cluster-helm
   url: https://github.com/zeebe-io/zeebe-cluster-helm
-  version: 0.0.80
-  versionURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.80
+  version: 0.0.81
+  versionURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.81
 - host: github.com
   owner: zeebe-io
   repo: zeebe-operate-helm

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: zeebe-io
   repo: zeebe-cluster-helm
   url: https://github.com/zeebe-io/zeebe-cluster-helm
-  version: 0.0.77
-  versionURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.77
+  version: 0.0.78
+  versionURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.78
 - host: github.com
   owner: zeebe-io
   repo: zeebe-operate-helm

--- a/zeebe-full/requirements.yaml
+++ b/zeebe-full/requirements.yaml
@@ -2,7 +2,7 @@ dependencies:
 - alias: zeebe
   name: zeebe-cluster
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.78
+  version: 0.0.79
 - alias: operate
   name: zeebe-operate
   repository: http://jenkins-x-chartmuseum:8080

--- a/zeebe-full/requirements.yaml
+++ b/zeebe-full/requirements.yaml
@@ -2,7 +2,7 @@ dependencies:
 - alias: zeebe
   name: zeebe-cluster
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.79
+  version: 0.0.80
 - alias: operate
   name: zeebe-operate
   repository: http://jenkins-x-chartmuseum:8080

--- a/zeebe-full/requirements.yaml
+++ b/zeebe-full/requirements.yaml
@@ -2,7 +2,7 @@ dependencies:
 - alias: zeebe
   name: zeebe-cluster
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.82
+  version: 0.0.83
 - alias: operate
   name: zeebe-operate
   repository: http://jenkins-x-chartmuseum:8080

--- a/zeebe-full/requirements.yaml
+++ b/zeebe-full/requirements.yaml
@@ -2,7 +2,7 @@ dependencies:
 - alias: zeebe
   name: zeebe-cluster
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.80
+  version: 0.0.81
 - alias: operate
   name: zeebe-operate
   repository: http://jenkins-x-chartmuseum:8080

--- a/zeebe-full/requirements.yaml
+++ b/zeebe-full/requirements.yaml
@@ -2,7 +2,7 @@ dependencies:
 - alias: zeebe
   name: zeebe-cluster
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.76
+  version: 0.0.77
 - alias: operate
   name: zeebe-operate
   repository: http://jenkins-x-chartmuseum:8080

--- a/zeebe-full/requirements.yaml
+++ b/zeebe-full/requirements.yaml
@@ -2,7 +2,7 @@ dependencies:
 - alias: zeebe
   name: zeebe-cluster
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.77
+  version: 0.0.78
 - alias: operate
   name: zeebe-operate
   repository: http://jenkins-x-chartmuseum:8080

--- a/zeebe-full/requirements.yaml
+++ b/zeebe-full/requirements.yaml
@@ -2,7 +2,7 @@ dependencies:
 - alias: zeebe
   name: zeebe-cluster
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.81
+  version: 0.0.82
 - alias: operate
   name: zeebe-operate
   repository: http://jenkins-x-chartmuseum:8080

--- a/zeebe-full/requirements.yaml
+++ b/zeebe-full/requirements.yaml
@@ -2,7 +2,7 @@ dependencies:
 - alias: zeebe
   name: zeebe-cluster
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.83
+  version: 0.0.84
 - alias: operate
   name: zeebe-operate
   repository: http://jenkins-x-chartmuseum:8080


### PR DESCRIPTION
Update [zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) from [0.0.76](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.76) to [0.0.84](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.84)

Command run was `jx step create pr chart --name zeebe-cluster --version 0.0.84 --repo https://github.com/zeebe-io/zeebe-full-helm.git`
<hr />

Update [zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) from [0.0.76](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.76) to [0.0.83](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.83)

Command run was `jx step create pr chart --name zeebe-cluster --version 0.0.83 --repo https://github.com/zeebe-io/zeebe-full-helm.git`
<hr />

Update [zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) from [0.0.76](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.76) to [0.0.82](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.82)

Command run was `jx step create pr chart --name zeebe-cluster --version 0.0.82 --repo https://github.com/zeebe-io/zeebe-full-helm.git`
<hr />

Update [zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) from [0.0.76](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.76) to [0.0.81](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.81)

Command run was `jx step create pr chart --name zeebe-cluster --version 0.0.81 --repo https://github.com/zeebe-io/zeebe-full-helm.git`
<hr />

Update [zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) from [0.0.76](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.76) to [0.0.80](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.80)

Command run was `jx step create pr chart --name zeebe-cluster --version 0.0.80 --repo https://github.com/zeebe-io/zeebe-full-helm.git`
<hr />

Update [zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) from [0.0.76](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.76) to [0.0.79](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.79)

Command run was `jx step create pr chart --name zeebe-cluster --version 0.0.79 --repo https://github.com/zeebe-io/zeebe-full-helm.git`
<hr />

Update [zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) from [0.0.76](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.76) to [0.0.78](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.78)

Command run was `jx step create pr chart --name zeebe-cluster --version 0.0.78 --repo https://github.com/zeebe-io/zeebe-full-helm.git`
<hr />

Update [zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) from [0.0.76](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.76) to [0.0.77](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.77)

Command run was `jx step create pr chart --name zeebe-cluster --version 0.0.77 --repo https://github.com/zeebe-io/zeebe-full-helm.git`