### PR TITLE
chore(deps): bump https://github.com/zeebe-io/zeebe-operate-helm from 0.0.20 to 0.0.21

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,4 +3,4 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.96](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.96) | 
-[zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.20](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.20) | 
+[zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.21](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.21) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -9,5 +9,5 @@ dependencies:
   owner: zeebe-io
   repo: zeebe-operate-helm
   url: https://github.com/zeebe-io/zeebe-operate-helm
-  version: 0.0.20
-  versionURL: https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.20
+  version: 0.0.21
+  versionURL: https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.21

--- a/zeebe-full/requirements.yaml
+++ b/zeebe-full/requirements.yaml
@@ -6,7 +6,7 @@ dependencies:
 - alias: operate
   name: zeebe-operate
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.20
+  version: 0.0.21
 - name: nginx-ingress
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 1.26.2


### PR DESCRIPTION
Update [zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) from [0.0.20](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.20) to [0.0.21](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.21)

Command run was `jx step create pr chart --name zeebe-operate --version 0.0.21 --repo https://github.com/zeebe-io/zeebe-full-helm.git`