### PR TITLE
chore(deps): bump

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,5 +2,5 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.119]() | 
+[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.121]() | 
 [zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.22](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.22) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,5 +2,5 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.121]() | 
-[zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.22](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.22) | 
+[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.113](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.113) | 
+[zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.24](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.24) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,5 +2,5 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.116](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.116) | 
+[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.119]() | 
 [zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.22](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.22) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,5 +2,5 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.113](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.113) | 
+[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.116](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.116) | 
 [zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.22](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.22) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: zeebe-io
   repo: zeebe-cluster-helm
   url: https://github.com/zeebe-io/zeebe-cluster-helm
-  version: 0.0.116
-  versionURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.116
+  version: 0.0.119
+  versionURL: ""
 - host: github.com
   owner: zeebe-io
   repo: zeebe-operate-helm

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,7 +3,7 @@ dependencies:
   owner: zeebe-io
   repo: zeebe-cluster-helm
   url: https://github.com/zeebe-io/zeebe-cluster-helm
-  version: 0.0.119
+  version: 0.0.121
   versionURL: ""
 - host: github.com
   owner: zeebe-io

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: zeebe-io
   repo: zeebe-cluster-helm
   url: https://github.com/zeebe-io/zeebe-cluster-helm
-  version: 0.0.113
-  versionURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.113
+  version: 0.0.116
+  versionURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.116
 - host: github.com
   owner: zeebe-io
   repo: zeebe-operate-helm

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -9,5 +9,5 @@ dependencies:
   owner: zeebe-io
   repo: zeebe-operate-helm
   url: https://github.com/zeebe-io/zeebe-operate-helm
-  version: 0.0.22
-  versionURL: https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.22
+  version: 0.0.24
+  versionURL: https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.24

--- a/zeebe-full/requirements.yaml
+++ b/zeebe-full/requirements.yaml
@@ -2,7 +2,7 @@ dependencies:
 - alias: zeebe
   name: zeebe-cluster
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.116
+  version: 0.0.119
 - alias: operate
   name: zeebe-operate
   repository: http://jenkins-x-chartmuseum:8080

--- a/zeebe-full/requirements.yaml
+++ b/zeebe-full/requirements.yaml
@@ -2,7 +2,7 @@ dependencies:
 - alias: zeebe
   name: zeebe-cluster
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.113
+  version: 0.0.116
 - alias: operate
   name: zeebe-operate
   repository: http://jenkins-x-chartmuseum:8080

--- a/zeebe-full/requirements.yaml
+++ b/zeebe-full/requirements.yaml
@@ -6,7 +6,7 @@ dependencies:
 - alias: operate
   name: zeebe-operate
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.22
+  version: 0.0.24
 - name: nginx-ingress
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 1.26.2

--- a/zeebe-full/requirements.yaml
+++ b/zeebe-full/requirements.yaml
@@ -2,7 +2,7 @@ dependencies:
 - alias: zeebe
   name: zeebe-cluster
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.119
+  version: 0.0.121
 - alias: operate
   name: zeebe-operate
   repository: http://jenkins-x-chartmuseum:8080


### PR DESCRIPTION
Update [zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) from [0.0.22](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.22) to [0.0.24](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.24)

Command run was `jx step create pr chart --name zeebe-operate --version 0.0.24 --repo https://github.com/zeebe-io/zeebe-full-helm.git`
<hr />

Update [zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) from [0.0.113](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.113) to 0.0.121

Command run was `jx step create pr chart --name zeebe-cluster --version 0.0.121 --repo https://github.com/zeebe-io/zeebe-full-helm.git`
<hr />

Update [zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) from [0.0.113](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.113) to 0.0.119

Command run was `jx step create pr chart --name zeebe-cluster --version 0.0.119 --repo https://github.com/zeebe-io/zeebe-full-helm.git`
<hr />

Update [zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) from [0.0.113](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.113) to [0.0.116](https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.116)

Command run was `jx step create pr chart --name zeebe-cluster --version 0.0.116 --repo https://github.com/zeebe-io/zeebe-full-helm.git`