### PR TITLE
chore(deps): bump https://github.com/zeebe-io/zeebe-tasklist-helm to 0.0.2

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -4,3 +4,4 @@ Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.128]() | 
 [zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.24](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.24) | 
+[zeebe-io/zeebe-tasklist-helm](https://github.com/zeebe-io/zeebe-tasklist-helm) |  | [0.0.2](https://github.com/zeebe-io/zeebe-tasklist-helm/releases/tag/v0.0.2) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -11,3 +11,9 @@ dependencies:
   url: https://github.com/zeebe-io/zeebe-operate-helm
   version: 0.0.24
   versionURL: https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.24
+- host: github.com
+  owner: zeebe-io
+  repo: zeebe-tasklist-helm
+  url: https://github.com/zeebe-io/zeebe-tasklist-helm
+  version: 0.0.2
+  versionURL: https://github.com/zeebe-io/zeebe-tasklist-helm/releases/tag/v0.0.2


### PR DESCRIPTION
Update [zeebe-io/zeebe-tasklist-helm](https://github.com/zeebe-io/zeebe-tasklist-helm) to [0.0.2](https://github.com/zeebe-io/zeebe-tasklist-helm/releases/tag/v0.0.2)

Command run was `jx step create pr chart --name zeebe-tasklist --version 0.0.2 --repo https://github.com/zeebe-io/zeebe-full-helm.git`