### PR TITLE
chore(deps): bump dependency versions

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,6 +2,6 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.128]() | 
+[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.141]() | 
 [zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.24](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.24) | 
 [zeebe-io/zeebe-tasklist-helm](https://github.com/zeebe-io/zeebe-tasklist-helm) |  | [0.0.4](https://github.com/zeebe-io/zeebe-tasklist-helm/releases/tag/v0.0.4) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,6 +2,6 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.141]() | 
-[zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.24](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.24) | 
+[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.128]() | 
+[zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.26](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.26) | 
 [zeebe-io/zeebe-tasklist-helm](https://github.com/zeebe-io/zeebe-tasklist-helm) |  | [0.0.4](https://github.com/zeebe-io/zeebe-tasklist-helm/releases/tag/v0.0.4) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,5 +3,5 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.128]() | 
-[zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.26](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.26) | 
+[zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.27](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.27) | 
 [zeebe-io/zeebe-tasklist-helm](https://github.com/zeebe-io/zeebe-tasklist-helm) |  | [0.0.4](https://github.com/zeebe-io/zeebe-tasklist-helm/releases/tag/v0.0.4) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -9,8 +9,8 @@ dependencies:
   owner: zeebe-io
   repo: zeebe-operate-helm
   url: https://github.com/zeebe-io/zeebe-operate-helm
-  version: 0.0.24
-  versionURL: https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.24
+  version: 0.0.26
+  versionURL: https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.26
 - host: github.com
   owner: zeebe-io
   repo: zeebe-tasklist-helm

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,7 +3,7 @@ dependencies:
   owner: zeebe-io
   repo: zeebe-cluster-helm
   url: https://github.com/zeebe-io/zeebe-cluster-helm
-  version: 0.0.128
+  version: 0.0.141
   versionURL: ""
 - host: github.com
   owner: zeebe-io

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -9,8 +9,8 @@ dependencies:
   owner: zeebe-io
   repo: zeebe-operate-helm
   url: https://github.com/zeebe-io/zeebe-operate-helm
-  version: 0.0.26
-  versionURL: https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.26
+  version: 0.0.27
+  versionURL: https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.27
 - host: github.com
   owner: zeebe-io
   repo: zeebe-tasklist-helm

--- a/zeebe-full/requirements.yaml
+++ b/zeebe-full/requirements.yaml
@@ -2,21 +2,21 @@ dependencies:
 - alias: zeebe
   name: zeebe-cluster
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.128
+  version: 0.0.141
 - alias: operate
   name: zeebe-operate
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.24
 - alias: zeeqs
+  condition: zeeqs.enabled
   name: zeeqs
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.11
-  condition: "zeeqs.enabled"  
 - alias: tasklist
+  condition: tasklist.enabled
   name: zeebe-tasklist
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.4
-  condition: "tasklist.enabled"
 - name: nginx-ingress
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 1.26.2

--- a/zeebe-full/requirements.yaml
+++ b/zeebe-full/requirements.yaml
@@ -6,7 +6,7 @@ dependencies:
 - alias: operate
   name: zeebe-operate
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.26
+  version: 0.0.27
 - alias: zeeqs
   condition: zeeqs.enabled
   name: zeeqs

--- a/zeebe-full/requirements.yaml
+++ b/zeebe-full/requirements.yaml
@@ -6,7 +6,7 @@ dependencies:
 - alias: operate
   name: zeebe-operate
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.24
+  version: 0.0.26
 - alias: zeeqs
   condition: zeeqs.enabled
   name: zeeqs


### PR DESCRIPTION
Update [zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) from [0.0.24](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.24) to [0.0.27](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.27)

Command run was `jx step create pr chart --name zeebe-operate --version 0.0.27 --repo https://github.com/zeebe-io/zeebe-full-helm.git`
<hr />

Update [zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) from [0.0.24](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.24) to [0.0.26](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.26)

Command run was `jx step create pr chart --name zeebe-operate --version 0.0.26 --repo https://github.com/zeebe-io/zeebe-full-helm.git`
<hr />

Update [zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) from 0.0.128 to 0.0.141

Command run was `jx step create pr chart --name zeebe-cluster --version 0.0.141 --repo https://github.com/zeebe-io/zeebe-full-helm.git`