### PR TITLE
chore(deps): bump dependency versions

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,6 +3,6 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.141]() | 
-[zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.28](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.28) | 
-[zeebe-io/zeebe-tasklist-helm](https://github.com/zeebe-io/zeebe-tasklist-helm) |  | [0.0.4](https://github.com/zeebe-io/zeebe-tasklist-helm/releases/tag/v0.0.4) | 
-[zeebe-io/zeebe-zeeqs-helm](https://github.com/zeebe-io/zeebe-zeeqs-helm) |  | [0.0.14](https://github.com/zeebe-io/zeebe-zeeqs-helm/releases/tag/v0.0.14) | 
+[zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.27](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.27) | 
+[zeebe-io/zeebe-tasklist-helm](https://github.com/zeebe-io/zeebe-tasklist-helm) |  | [0.0.6](https://github.com/zeebe-io/zeebe-tasklist-helm/releases/tag/v0.0.6) | 
+[zeebe-io/zeebe-zeeqs-helm](https://github.com/zeebe-io/zeebe-zeeqs-helm) |  | [0.0.13](https://github.com/zeebe-io/zeebe-zeeqs-helm/releases/tag/v0.0.13) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,7 +2,7 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.141]() | 
+[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.142]() | 
 [zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.27](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.27) | 
 [zeebe-io/zeebe-tasklist-helm](https://github.com/zeebe-io/zeebe-tasklist-helm) |  | [0.0.4](https://github.com/zeebe-io/zeebe-tasklist-helm/releases/tag/v0.0.4) | 
 [zeebe-io/zeebe-zeeqs-helm](https://github.com/zeebe-io/zeebe-zeeqs-helm) |  | [0.0.13](https://github.com/zeebe-io/zeebe-zeeqs-helm/releases/tag/v0.0.13) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -5,4 +5,4 @@ Dependency | Sources | Version | Mismatched versions
 [zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.141]() | 
 [zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.28](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.28) | 
 [zeebe-io/zeebe-tasklist-helm](https://github.com/zeebe-io/zeebe-tasklist-helm) |  | [0.0.4](https://github.com/zeebe-io/zeebe-tasklist-helm/releases/tag/v0.0.4) | 
-[zeebe-io/zeebe-zeeqs-helm](https://github.com/zeebe-io/zeebe-zeeqs-helm) |  | [0.0.13](https://github.com/zeebe-io/zeebe-zeeqs-helm/releases/tag/v0.0.13) | 
+[zeebe-io/zeebe-zeeqs-helm](https://github.com/zeebe-io/zeebe-zeeqs-helm) |  | [0.0.14](https://github.com/zeebe-io/zeebe-zeeqs-helm/releases/tag/v0.0.14) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,7 +2,7 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.142]() | 
-[zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.27](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.27) | 
+[zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) |  | [0.0.141]() | 
+[zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) |  | [0.0.28](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.28) | 
 [zeebe-io/zeebe-tasklist-helm](https://github.com/zeebe-io/zeebe-tasklist-helm) |  | [0.0.4](https://github.com/zeebe-io/zeebe-tasklist-helm/releases/tag/v0.0.4) | 
 [zeebe-io/zeebe-zeeqs-helm](https://github.com/zeebe-io/zeebe-zeeqs-helm) |  | [0.0.13](https://github.com/zeebe-io/zeebe-zeeqs-helm/releases/tag/v0.0.13) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,7 +3,7 @@ dependencies:
   owner: zeebe-io
   repo: zeebe-cluster-helm
   url: https://github.com/zeebe-io/zeebe-cluster-helm
-  version: 0.0.141
+  version: 0.0.142
   versionURL: ""
 - host: github.com
   owner: zeebe-io

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -21,5 +21,5 @@ dependencies:
   owner: zeebe-io
   repo: zeebe-zeeqs-helm
   url: https://github.com/zeebe-io/zeebe-zeeqs-helm
-  version: 0.0.13
-  versionURL: https://github.com/zeebe-io/zeebe-zeeqs-helm/releases/tag/v0.0.13
+  version: 0.0.14
+  versionURL: https://github.com/zeebe-io/zeebe-zeeqs-helm/releases/tag/v0.0.14

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -9,8 +9,8 @@ dependencies:
   owner: zeebe-io
   repo: zeebe-operate-helm
   url: https://github.com/zeebe-io/zeebe-operate-helm
-  version: 0.0.27
-  versionURL: https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.27
+  version: 0.0.28
+  versionURL: https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.28
 - host: github.com
   owner: zeebe-io
   repo: zeebe-tasklist-helm

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -15,8 +15,8 @@ dependencies:
   owner: zeebe-io
   repo: zeebe-tasklist-helm
   url: https://github.com/zeebe-io/zeebe-tasklist-helm
-  version: 0.0.4
-  versionURL: https://github.com/zeebe-io/zeebe-tasklist-helm/releases/tag/v0.0.4
+  version: 0.0.6
+  versionURL: https://github.com/zeebe-io/zeebe-tasklist-helm/releases/tag/v0.0.6
 - host: github.com
   owner: zeebe-io
   repo: zeebe-zeeqs-helm

--- a/zeebe-full/requirements.yaml
+++ b/zeebe-full/requirements.yaml
@@ -6,7 +6,7 @@ dependencies:
 - alias: operate
   name: zeebe-operate
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.27
+  version: 0.0.28
 - alias: zeeqs
   condition: zeeqs.enabled
   name: zeeqs

--- a/zeebe-full/requirements.yaml
+++ b/zeebe-full/requirements.yaml
@@ -11,7 +11,7 @@ dependencies:
   condition: zeeqs.enabled
   name: zeeqs
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.13
+  version: 0.0.14
 - alias: tasklist
   condition: tasklist.enabled
   name: zeebe-tasklist

--- a/zeebe-full/requirements.yaml
+++ b/zeebe-full/requirements.yaml
@@ -2,7 +2,7 @@ dependencies:
 - alias: zeebe
   name: zeebe-cluster
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.141
+  version: 0.0.142
 - alias: operate
   name: zeebe-operate
   repository: http://jenkins-x-chartmuseum:8080

--- a/zeebe-full/requirements.yaml
+++ b/zeebe-full/requirements.yaml
@@ -16,7 +16,7 @@ dependencies:
   condition: tasklist.enabled
   name: zeebe-tasklist
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.5
+  version: 0.0.6
 - name: nginx-ingress
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 1.26.2


### PR DESCRIPTION
Update [zeebe-io/zeebe-tasklist-helm](https://github.com/zeebe-io/zeebe-tasklist-helm) from [0.0.5](https://github.com/zeebe-io/zeebe-tasklist-helm/releases/tag/v0.0.5) to [0.0.6](https://github.com/zeebe-io/zeebe-tasklist-helm/releases/tag/v0.0.6)

Command run was `jx step create pr chart --name zeebe-tasklist --version 0.0.6 --repo https://github.com/zeebe-io/zeebe-full-helm.git`
<hr />

Update [zeebe-io/zeebe-zeeqs-helm](https://github.com/zeebe-io/zeebe-zeeqs-helm) from [0.0.13](https://github.com/zeebe-io/zeebe-zeeqs-helm/releases/tag/v0.0.13) to [0.0.14](https://github.com/zeebe-io/zeebe-zeeqs-helm/releases/tag/v0.0.14)

Command run was `jx step create pr chart --name zeeqs --version 0.0.14 --repo https://github.com/zeebe-io/zeebe-full-helm.git`
<hr />

Update [zeebe-io/zeebe-operate-helm](https://github.com/zeebe-io/zeebe-operate-helm) from [0.0.27](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.27) to [0.0.28](https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.28)

Command run was `jx step create pr chart --name zeebe-operate --version 0.0.28 --repo https://github.com/zeebe-io/zeebe-full-helm.git`
<hr />

Update [zeebe-io/zeebe-cluster-helm](https://github.com/zeebe-io/zeebe-cluster-helm) from 0.0.141 to 0.0.142

Command run was `jx step create pr chart --name zeebe-cluster --version 0.0.142 --repo https://github.com/zeebe-io/zeebe-full-helm.git`