### PR TITLE
Updated ingress-nginx dependency to official chart

### DIFF
--- a/charts/zeebe-full-helm/Chart.yaml
+++ b/charts/zeebe-full-helm/Chart.yaml
@@ -20,6 +20,6 @@ dependencies:
   name: zeebe-tasklist-helm
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.10
-- name: nginx-ingress
-  repository: https://kubernetes-charts.storage.googleapis.com
-  version: 1.26.2
+- name: ingress-nginx
+  repository: https://kubernetes.github.io/ingress-nginx
+  version: 3.19.0


### PR DESCRIPTION
- [Kubernetes](https://kubernetes-charts.storage.googleapis.com) charts are deprecated
- Updated ingress-nginx to use latest official [charts](https://github.com/kubernetes/ingress-nginx/tree/master/charts/ingress-nginx)
- Updated to the latest version available