### PR TITLE
Update Zeebe, Operate, and Tasklist to 1.1.2

### DIFF
--- a/charts/zeebe-full-helm/Chart.yaml
+++ b/charts/zeebe-full-helm/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "1.0.0"
+appVersion: "1.1.2"
 description: Zeebe Cluster + Operate Helm Chart for Kubernetes
 name: zeebe-full-helm
 version: 0.1.0-SNAPSHOT
@@ -8,10 +8,10 @@ icon: https://zeebe.io/img/zeebe-logo.png
 dependencies:
 - name: zeebe-cluster-helm
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.223
+  version: 0.0.225
 - name: zeebe-operate-helm
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.50
+  version: 0.0.51
 - condition: zeeqs.enabled
   name: zeebe-zeeqs-helm
   repository: http://jenkins-x-chartmuseum:8080
@@ -19,7 +19,7 @@ dependencies:
 - condition: tasklist.enabled
   name: zeebe-tasklist-helm
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.16
+  version: 0.0.17
 - condition: cloudevents.enabled
   name: zeebe-cloud-events-router
   repository: http://jenkins-x-chartmuseum:8080


### PR DESCRIPTION
Please double-check the version numbers once the dependencies have been released, as I've interpolated what the new version numbers should be.